### PR TITLE
Add new JSON properties of Tonie API

### DIFF
--- a/src/main/java/rocks/voss/toniebox/beans/toniebox/CreativeTonie.java
+++ b/src/main/java/rocks/voss/toniebox/beans/toniebox/CreativeTonie.java
@@ -17,6 +17,7 @@ public class CreativeTonie {
     private boolean live;
     private boolean isPrivate;
     private String imageUrl;
+    private String[] transcodingErrors;
     private boolean transcoding;
     private float secondsPresent;
     private float secondsRemaining;

--- a/src/main/java/rocks/voss/toniebox/beans/toniebox/Household.java
+++ b/src/main/java/rocks/voss/toniebox/beans/toniebox/Household.java
@@ -10,4 +10,5 @@ public class Household {
     private boolean foreignCreativeTonieContent;
     private String access;
     private boolean canLeave;
+    private String ownerName;
 }


### PR DESCRIPTION
The Tonie API is returning some new fields that are causing the JSON parsing to fail, as also reported in https://github.com/maximilianvoss/spotify-toniebox-sync/issues/2. This PR is adding the new properties.

In case of `transcodingErrors` I used `String[]` as type due to the fact that I don't know the actual structure and it probably does not matter so much.