### PR TITLE
Fixes file upload to AWS

### DIFF
--- a/src/main/java/rocks/voss/toniebox/beans/amazon/FieldsBean.java
+++ b/src/main/java/rocks/voss/toniebox/beans/amazon/FieldsBean.java
@@ -15,4 +15,6 @@ public class FieldsBean {
 	private String xAmzDate;
 	@JsonProperty("x-amz-signature")
 	private String xAmzSignature;
+	@JsonProperty("x-amz-security-token")
+	private String xAmzSecurityToken;
 }


### PR DESCRIPTION
It seems that toniecloud at some point switched the way uploads work. The /file POST request now returns an additional field (x-aws-security-token) which must be included in the AWS upload request. Without this field, the AWS API returns a 403 (which is silently ignored).

Add the security header. Also report the content of an API response if no bean is given.